### PR TITLE
add data-attributes and print form data in order for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,22 @@ Here's a *snapshot* of the script you need (*at this point in the exercise*): [g
 
 ### 3. Set the `TO_ADDRESS` in the Script
 
-In the editor window you should expect to see:
+**_Warning:_** If you do not uncomment and set your email as the value of
+`TO_ADDRESS`, it is possible for someone who has web skills to alter your form
+and send emailed data to an arbitrary email address.
+
+This risk may not be very likely. Instead, if you wish, you can leave this
+variable commented out if you accept this possible risk but want the added
+convenience of setting this email variable inside your HTML form as a
+`data-email` attribute. This allows you to easily change where to send emails
+inside your HTML form without going back through steps 2-6. This functionality
+does **require** you to use the provided JS file in Part Two, Step 10.
+
+If you do not want to accept that potential risk, please uncomment the code for
+the variable `TO_ADDRESS`, and set this value equal to the email which should
+receive the form's data when submitted.
 
 ![3-script-editor-showing-script](https://cloud.githubusercontent.com/assets/194400/10560379/9efa5b3a-7501-11e5-96ba-a9e3b2d77ee4.png)
-
-Change the value of the `TO_ADDRESS` to which ever email you want to receive
-the contact form message.
 
 ### 4. Save a *New Version* of your Script
 
@@ -139,6 +149,11 @@ Update your `index.html` to include the following JavaScript file at the *end* o
 <script data-cfasync="false" type="text/javascript"
 src="https://cdn.rawgit.com/dwyl/html-form-send-email-via-google-script-without-server/master/form-submission-handler.js"></script>
 ```
+
+**Warning:** If you did not set the `TO_ADDRESS` variable in Step 3, then
+you need to include a `data-email="example@email.net"` attribute inside the
+main form element. See the example form for more details. Otherwise, if you did
+set this variable, then you do not need this form attribute.
 
 This will now display a "Thank You" *message* when the form is submitted:
 

--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -5,7 +5,8 @@ function validEmail(email) { // see:
 }
 // get all data in form and return object
 function getFormData() {
-  var elements = document.getElementById("gform").elements; // all form elements
+  var form = document.getElementById("gform");
+  var elements = form.elements; // all form elements
   var fields = Object.keys(elements).map(function(k) {
     if(elements[k].name !== undefined) {
       return elements[k].name;
@@ -38,6 +39,12 @@ function getFormData() {
       }
     }
   });
+
+  // add form-specific values into the data
+  data.formDataNameOrder = JSON.stringify(fields);
+  data.formGoogleSheetName = form.dataset.sheet || "responses"; // default sheet name
+  data.formGoogleSendEmail = form.dataset.email || ""; // no email by default
+
   console.log(data);
   return data;
 }

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -4,6 +4,9 @@
  * All credit still goes to Martin and any issues/complaints/questions to me. *
  ******************************************************************************/
 
+// if you want to store your email server-side (hidden), uncomment the next line
+// var TO_ADDRESS = "contact.nelsonic+form.submit@gmail.com";
+
 // spit out all the keys/values from the form in HTML for email
 function formatMailBody(obj, order) {
   var result = "";
@@ -29,8 +32,13 @@ function doPost(e) {
     // names and order of form elements
     var dataOrder = JSON.parse(e.parameters.formDataNameOrder);
     
+    // determine recepient of the email
+    // if you have your email uncommented above, it uses that `TO_ADDRESS`
+    // otherwise, it defaults to the email provided by the form's data attribute
+    var sendEmailTo = (typeof TO_ADDRESS !== "undefined") ? TO_ADDRESS : mailData.formGoogleSendEmail;
+    
     MailApp.sendEmail({
-      to: String(mailData.formGoogleSendEmail),
+      to: String(sendEmailTo),
       subject: "Contact form submitted",
       // replyTo: String(mailData.email), // This is optional and reliant on your form actually collecting a field named `email`
       htmlBody: formatMailBody(mailData, dataOrder)

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 // if you want to store your email server-side (hidden), uncomment the next line
-// var TO_ADDRESS = "contact.nelsonic+form.submit@gmail.com";
+// var TO_ADDRESS = "example@email.net";
 
 // spit out all the keys/values from the form in HTML for email
 function formatMailBody(obj, order) {

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -4,11 +4,12 @@
  * All credit still goes to Martin and any issues/complaints/questions to me. *
  ******************************************************************************/
 
-var TO_ADDRESS = "contact.nelsonic+form.submit@gmail.com"; // change this ...
-
-function formatMailBody(obj) { // function to spit out all the keys/values from the form in HTML
+// spit out all the keys/values from the form in HTML for email
+function formatMailBody(obj, order) {
   var result = "";
-  for (var key in obj) { // loop over the object passed to the function
+  // loop over all keys in the ordered form data
+  for (var idx in order) {
+    var key = order[idx];
     result += "<h4 style='text-transform: capitalize; margin-bottom: 0'>" + key + "</h4><div>" + obj[key] + "</div>";
     // for every key, concatenate an `<h4 />`/`<div />` pairing of the key name and its value, 
     // and append it to the `result` string created at the start.
@@ -21,14 +22,18 @@ function doPost(e) {
   try {
     Logger.log(e); // the Google Script version of console.log see: Class Logger
     record_data(e);
-
-    var mailData = e.parameters; // just create a slightly nicer variable name for the data
+    
+    // shorter name for form data
+    var mailData = e.parameters;
+    
+    // names and order of form elements
+    var dataOrder = JSON.parse(e.parameters.formDataNameOrder);
     
     MailApp.sendEmail({
-      to: TO_ADDRESS,
+      to: String(mailData.formGoogleSendEmail),
       subject: "Contact form submitted",
       // replyTo: String(mailData.email), // This is optional and reliant on your form actually collecting a field named `email`
-      htmlBody: formatMailBody(mailData)
+      htmlBody: formatMailBody(mailData, dataOrder)
     });
 
     return ContentService    // return json success results
@@ -53,7 +58,7 @@ function record_data(e) {
   Logger.log(JSON.stringify(e)); // log the POST data in case we need to debug it
   try {
     var doc     = SpreadsheetApp.getActiveSpreadsheet();
-    var sheet   = doc.getSheetByName('responses'); // select the responses sheet
+    var sheet   = doc.getSheetByName(e.parameters.formGoogleSheetName); // select the 'responses' sheet by default
     var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
     var nextRow = sheet.getLastRow()+1; // get next row
     var row     = [ new Date() ]; // first element in the row should always be a timestamp

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
    <!-- Style The Contact Form How Ever You Prefer -->
    <link rel="stylesheet" href="https://cdn.rawgit.com/dwyl/html-form-send-email-via-google-script-without-server/master/style.css">
 
-  <form id="gform" method="POST" class="pure-form pure-form-stacked"
+  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="contact.nelsonic+form.submit@gmail.com"
   action="https://script.google.com/macros/s/AKfycbwMxYDrufp73bKdU8gMvxFDdHRuzcR4IKQUB33B7GqwyfyZS04/exec">
     <!-- change the form action to your script url -->
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
    <!-- Style The Contact Form How Ever You Prefer -->
    <link rel="stylesheet" href="https://cdn.rawgit.com/dwyl/html-form-send-email-via-google-script-without-server/master/style.css">
 
-  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="contact.nelsonic+form.submit@gmail.com"
+  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="example@email.net"
   action="https://script.google.com/macros/s/AKfycbwMxYDrufp73bKdU8gMvxFDdHRuzcR4IKQUB33B7GqwyfyZS04/exec">
     <!-- change the form action to your script url -->
 

--- a/test.html
+++ b/test.html
@@ -26,7 +26,7 @@
   </p>
 
 
-  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="contact.nelsonic+form.submit@gmail.com" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
+  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="example@email.net" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
 
     <!--submit/button-->
     <button class="button-success pure-button button-xlarge">

--- a/test.html
+++ b/test.html
@@ -26,7 +26,7 @@
   </p>
 
 
-  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="mckennapsean.test@gmail.com" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
+  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="contact.nelsonic+form.submit@gmail.com" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
 
     <!--submit/button-->
     <button class="button-success pure-button button-xlarge">

--- a/test.html
+++ b/test.html
@@ -26,7 +26,7 @@
   </p>
 
 
-  <form id="gform" method="POST" class="pure-form pure-form-stacked" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
+  <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="mckennapsean.test@gmail.com" action="https://script.google.com/macros/s/AKfycbyF7zsZXQUZLKBOaVKfsrzyr30FPHprgqd8flvC5WeuYQJnc5E/exec">
 
     <!--submit/button-->
     <button class="button-success pure-button button-xlarge">


### PR DESCRIPTION
Fixes #76 and pulled in some ideas from #90 to store data in the HTML form element.

For example, the HTML element can contain a `data-sheet="responses"` to send the data into responses sheet, or whichever sheet you want. By default, no data element uses the same default before (no breaking functionality). Similarly, you have to use `data-email` if you want to send an email in the Google Script (or set the variable in the Javascript).

The motivation is that I am trying to make it easier for people to just use the Javascript and Google Script without changing them. They just change things in the HTML, which makes it easier to deploy changes, like changing emails or which spreadsheet to store data in.

I think there are more things we can move here, over time, but I wanted to see what people think of this idea.

Lastly, I have the form fields get stored as a stringified array and use that array later when printing out the email. This makes sure that the email gets printed out in order of the form data! :)