### PR TITLE
Sanitize user submitted content

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -13,7 +13,7 @@ function formatMailBody(obj, order) {
   // loop over all keys in the ordered form data
   for (var idx in order) {
     var key = order[idx];
-    result += "<h4 style='text-transform: capitalize; margin-bottom: 0'>" + key + "</h4><div>" + cleanMe(obj[key]) + "</div>";
+    result += "<h4 style='text-transform: capitalize; margin-bottom: 0'>" + key + "</h4><div>" + sanitizeInput(obj[key]) + "</div>";
     // for every key, concatenate an `<h4 />`/`<div />` pairing of the key name and its value, 
     // and append it to the `result` string created at the start.
   }
@@ -22,10 +22,9 @@ function formatMailBody(obj, order) {
 
 // sanitize content from the user - trust no one 
 // ref: https://developers.google.com/apps-script/reference/html/html-output#appendUntrusted(String)
-function cleanMe(theunclean) {
-   var output = HtmlService.createHtmlOutput(theunclean);
-   var placeholder = HtmlService.createHtmlOutput(' ');
-   placeholder.appendUntrusted(theunclean);
+function sanitizeInput(rawInput) {
+   var placeholder = HtmlService.createHtmlOutput(" ");
+   placeholder.appendUntrusted(rawInput);
   
    return placeholder.getContent();
  }

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -13,12 +13,22 @@ function formatMailBody(obj, order) {
   // loop over all keys in the ordered form data
   for (var idx in order) {
     var key = order[idx];
-    result += "<h4 style='text-transform: capitalize; margin-bottom: 0'>" + key + "</h4><div>" + obj[key] + "</div>";
+    result += "<h4 style='text-transform: capitalize; margin-bottom: 0'>" + key + "</h4><div>" + cleanMe(obj[key]) + "</div>";
     // for every key, concatenate an `<h4 />`/`<div />` pairing of the key name and its value, 
     // and append it to the `result` string created at the start.
   }
   return result; // once the looping is done, `result` will be one long string to put in the email body
 }
+
+// sanitize content from the user - trust no one 
+// ref: https://developers.google.com/apps-script/reference/html/html-output#appendUntrusted(String)
+function cleanMe(theunclean) {
+   var output = HtmlService.createHtmlOutput(theunclean);
+   var placeholder = HtmlService.createHtmlOutput(' ');
+   placeholder.appendUntrusted(theunclean);
+  
+   return placeholder.getContent();
+ }
 
 function doPost(e) {
 


### PR DESCRIPTION
Utilize  appendUntrusted() to safely escape any content from the user (e.g., malicious HTML or javascript).